### PR TITLE
Postgres SSL connection option

### DIFF
--- a/__tests__/PostgreSqlManager.js
+++ b/__tests__/PostgreSqlManager.js
@@ -10,7 +10,8 @@ const options = {
   server: "127.0.0.1",
   options: {
     port: 5432,
-    database: "user"
+    database: "user",
+    ssl: false
   }
 };
 const testRequest = {
@@ -74,6 +75,20 @@ describe('Wrong connection options', () => {
         .rejects
         .toMatchObject({message: "database \"" + wrongOptions.options.database + "\" does not exist"});
   });
+
+  // test("SSL required database", () => {
+  //   // NOTE: Recommended that the author setup a free hosted Postgres instance for testing valid SSL connections
+  //   const wrongOptions = JSON.parse(JSON.stringify(options));
+  //   // NOTE: public testing postgresql server that has ssl enabled
+  //   wrongOptions.server = "";
+  //   wrongOptions.options.ssl = false;
+  //   const manager = new PostgreSqlManager(wrongOptions);
+
+  //   expect.assertions(1);
+  //   return expect(manager.executeSql(testRequest))
+  //     .rejects
+  //     .toMatchObject({mesesage: "no pg_hba.conf entry for host \"" + wrongOptions.server + "\", user \"" + wrongOptions.userName + "\", database \"" + wrongOptions.options.database + "\", SSL off"})
+  // })
 });
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2161,12 +2161,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2181,17 +2183,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2308,7 +2313,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2320,6 +2326,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2334,6 +2341,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2341,12 +2349,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2365,6 +2375,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2445,7 +2456,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2457,6 +2469,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2578,6 +2591,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/postgresql/PostgreSqlManager.js
+++ b/postgresql/PostgreSqlManager.js
@@ -16,6 +16,7 @@ class PostgreSqlManager extends DbManager {
       host: options.server,
       port: options.options.port,
       database: options.options.database || options.userName,
+      ssl: options.options.ssl,
       logging: options.options.logging
     }));
   }

--- a/postgresql/PostgreSqlPreferences.js
+++ b/postgresql/PostgreSqlPreferences.js
@@ -16,19 +16,8 @@ class PostgreSqlPreferences extends DbPreferences {
    * @return {object}
    */
   getConnOptions() {
-    return {
-      userName: app.preferences.get(this.connPrefKeyPrefix + ".username"),
-      password: app.preferences.get(this.connPrefKeyPrefix + ".password"),
-      server: app.preferences.get(this.connPrefKeyPrefix + ".server"),
-      owner: app.preferences.get(this.connPrefKeyPrefix + ".owner"),
-      options: {
-        port: app.preferences.get(this.connPrefOptKeyPrefix + ".port"),
-        database: app.preferences.get(this.connPrefOptKeyPrefix + ".database"),
-        logging: app.preferences.get(this.connPrefOptKeyPrefix + ".logging"),
-        ssl: app.preferences.get(this.connPrefOptKeyPrefix + ".ssl")
-      }
-    };
-  };
+    return Object.assign({options: {ssl: app.preferences.get(this.connPrefOptKeyPrefix + ".ssl")}}, super.getConnOptions());
+  }
 }
 
 module.exports = PostgreSqlPreferences;

--- a/postgresql/PostgreSqlPreferences.js
+++ b/postgresql/PostgreSqlPreferences.js
@@ -9,6 +9,26 @@ class PostgreSqlPreferences extends DbPreferences {
   constructor() {
     super("db.postgresql");
   }
+
+  /**
+   * Connection options
+   *
+   * @return {object}
+   */
+  getConnOptions() {
+    return {
+      userName: app.preferences.get(this.connPrefKeyPrefix + ".username"),
+      password: app.preferences.get(this.connPrefKeyPrefix + ".password"),
+      server: app.preferences.get(this.connPrefKeyPrefix + ".server"),
+      owner: app.preferences.get(this.connPrefKeyPrefix + ".owner"),
+      options: {
+        port: app.preferences.get(this.connPrefOptKeyPrefix + ".port"),
+        database: app.preferences.get(this.connPrefOptKeyPrefix + ".database"),
+        logging: app.preferences.get(this.connPrefOptKeyPrefix + ".logging"),
+        ssl: app.preferences.get(this.connPrefOptKeyPrefix + ".ssl")
+      }
+    };
+  };
 }
 
 module.exports = PostgreSqlPreferences;

--- a/preferences/postgresql.json
+++ b/preferences/postgresql.json
@@ -46,6 +46,12 @@
       "type": "string",
       "default": ""
     },
+    "db.postgresql.connection.options.ssl": {
+      "text": "SSL",
+      "description": "Enable SSL",
+      "type": "check",
+      "default": false
+    },
     "db.postgresql.connection.options.logging": {
       "text": "Logging",
       "description": "Logging",


### PR DESCRIPTION
**- What I did**

Added option to enable SSL for Postgres connections. (_Required for many hosted instances of Postgres_)

Fixes: #34 

**- How I did it**

- Added preference for enabling ssl in `preferences/postgresql.json`
- Adding `ssl` attr to `getConnOptions` for `postgresql/PostgreSqlPreferences.js`
- Passing `ssl` option through `postgresql/PostgreSqlManager.js`

- Also added `ssl: false` for `__tests__/PostgreSqlManager.js` 

**- How to verify it**

I wouldn't merge this until the author recommends on the process for testing SSL connections. In my mind there are two options:

1. Setup some free hosting instance (like Heroku) to host a testing database instance
2. Generate and setup ssl certificates in the setup for the Postgres container ([reference](https://github.com/adrienkohlbecker/docker-postgres/blob/master/9.4/enable-ssl.sh))

**I'll wait for your recommendation**

**- Description for the changelog**

- Added SSL toggle for Postgres connections
